### PR TITLE
feat: allow to set custom arguments for package manager

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -83,6 +83,7 @@ const defaultOptions = {
     type: this.getDefaultPackageManager(),
     options: {
       dev: false,
+      quiet: false,
     },
   },
   prompt: true,
@@ -268,6 +269,7 @@ module.exports.install = async function install(deps, options, logger) {
 
   let args;
   let client;
+  let quietOptions;
   let save;
 
   const { packageManager } = options;
@@ -280,6 +282,7 @@ module.exports.install = async function install(deps, options, logger) {
     client = 'yarn';
     save =
       packageManager.options && packageManager.options.dev ? '--dev' : null;
+    quietOptions = ['--silent'];
   } else if (
     packageManager === 'pnpm' ||
     (packageManager && packageManager.type === 'pnpm')
@@ -290,6 +293,7 @@ module.exports.install = async function install(deps, options, logger) {
       packageManager.options && packageManager.options.dev
         ? '--save-dev'
         : null;
+    quietOptions = [];
   } else {
     args = ['install'];
     client = 'npm';
@@ -297,6 +301,7 @@ module.exports.install = async function install(deps, options, logger) {
       packageManager.options && packageManager.options.dev
         ? '--save-dev'
         : '--save';
+    quietOptions = ['--silent', '--no-progress'];
   }
 
   if (options.prompt) {
@@ -326,6 +331,10 @@ module.exports.install = async function install(deps, options, logger) {
 
   if (packageManager.options && packageManager.options.arguments) {
     args = args.concat(packageManager.options.arguments);
+  }
+
+  if (packageManager.options && packageManager.options.quiet) {
+    args = args.concat(quietOptions);
   }
 
   deps.forEach((dep) => {

--- a/src/installer.js
+++ b/src/installer.js
@@ -85,7 +85,6 @@ const defaultOptions = {
       dev: false,
     },
   },
-  quiet: false,
   prompt: true,
 };
 
@@ -269,7 +268,6 @@ module.exports.install = async function install(deps, options, logger) {
 
   let args;
   let client;
-  let quietOptions;
   let save;
 
   const { packageManager } = options;
@@ -282,7 +280,6 @@ module.exports.install = async function install(deps, options, logger) {
     client = 'yarn';
     save =
       packageManager.options && packageManager.options.dev ? '--dev' : null;
-    quietOptions = ['--silent'];
   } else if (
     packageManager === 'pnpm' ||
     (packageManager && packageManager.type === 'pnpm')
@@ -293,7 +290,6 @@ module.exports.install = async function install(deps, options, logger) {
       packageManager.options && packageManager.options.dev
         ? '--save-dev'
         : null;
-    quietOptions = [];
   } else {
     args = ['install'];
     client = 'npm';
@@ -301,7 +297,6 @@ module.exports.install = async function install(deps, options, logger) {
       packageManager.options && packageManager.options.dev
         ? '--save-dev'
         : '--save';
-    quietOptions = ['--silent', '--no-progress'];
   }
 
   if (options.prompt) {
@@ -329,8 +324,8 @@ module.exports.install = async function install(deps, options, logger) {
     args.push(save);
   }
 
-  if (options.quiet) {
-    args = args.concat(quietOptions);
+  if (packageManager.options && packageManager.options.arguments) {
+    args = args.concat(packageManager.options.arguments);
   }
 
   deps.forEach((dep) => {

--- a/src/installer.js
+++ b/src/installer.js
@@ -293,7 +293,7 @@ module.exports.install = async function install(deps, options, logger) {
       packageManager.options && packageManager.options.dev
         ? '--save-dev'
         : null;
-    quietOptions = [];
+    quietOptions = ['--reporter=silent'];
   } else {
     args = ['install'];
     client = 'npm';

--- a/src/options.json
+++ b/src/options.json
@@ -43,6 +43,14 @@
                 "dev": {
                   "type": "boolean",
                   "description": "Install as development dependencies"
+                },
+                "arguments": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }

--- a/src/options.json
+++ b/src/options.json
@@ -40,10 +40,6 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "dev": {
-                  "type": "boolean",
-                  "description": "Install as development dependencies"
-                },
                 "arguments": {
                   "type": "array",
                   "minItems": 1,
@@ -51,6 +47,14 @@
                     "type": "string",
                     "minLength": 1
                   }
+                },
+                "dev": {
+                  "type": "boolean",
+                  "description": "Install as development dependencies"
+                },
+                "quiet": {
+                  "type": "boolean",
+                  "description": " Reduce amount of console logging"
                 }
               }
             }
@@ -65,10 +69,6 @@
     "Prompt": {
       "type": "boolean",
       "description": "Show a prompt to confirm installation."
-    },
-    "Quiet": {
-      "type": "boolean",
-      "description": " Reduce amount of console logging"
     }
   },
   "additionalProperties": false,
@@ -81,9 +81,6 @@
     },
     "prompt": {
       "$ref": "#/definitions/Prompt"
-    },
-    "quiet": {
-      "$ref": "#/definitions/Quiet"
     }
   }
 }

--- a/test/__snapshots__/installer.test.js.snap
+++ b/test/__snapshots__/installer.test.js.snap
@@ -170,6 +170,24 @@ Array [
 ]
 `;
 
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with --silent when quiet is true 1`] = `
+Array [
+  "pnpm",
+  Array [
+    "add",
+    "foo",
+    "--reporter=silent",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
 exports[`installer .install when using pnpm given a dependency with package manager options should install it with all arguments 1`] = `
 Array [
   "pnpm",
@@ -178,6 +196,7 @@ Array [
     "foo",
     "--save-dev",
     "--ignore-workspace-root-check",
+    "--reporter=silent",
   ],
   Object {
     "stdio": Array [

--- a/test/__snapshots__/installer.test.js.snap
+++ b/test/__snapshots__/installer.test.js.snap
@@ -20,6 +20,84 @@ Array [
 ]
 `;
 
+exports[`installer .install when using npm given a dependency with package manager options should install it with --ignore-scripts 1`] = `
+Array [
+  "npm",
+  Array [
+    "install",
+    "foo",
+    "--save",
+    "--ignore-scripts",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using npm given a dependency with package manager options should install it with --save-dev 1`] = `
+Array [
+  "npm",
+  Array [
+    "install",
+    "foo",
+    "--save-dev",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using npm given a dependency with package manager options should install it with --silent when quiet is true 1`] = `
+Array [
+  "npm",
+  Array [
+    "install",
+    "foo",
+    "--save",
+    "--silent",
+    "--no-progress",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using npm given a dependency with package manager options should install it with all arguments 1`] = `
+Array [
+  "npm",
+  Array [
+    "install",
+    "foo",
+    "--save-dev",
+    "--ignore-scripts",
+    "--silent",
+    "--no-progress",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
 exports[`installer .install when using pnpm given a dependency with missing peerDependencies given peerDependencies set to false should not install peerDependencies 1`] = `
 Array [
   Array [
@@ -39,6 +117,78 @@ Array [
 ]
 `;
 
+exports[`installer .install when using pnpm given a dependency with no options should install it without addition arguments 1`] = `
+Array [
+  "pnpm",
+  Array [
+    "add",
+    "foo",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with --ignore-workspace-root-check 1`] = `
+Array [
+  "pnpm",
+  Array [
+    "add",
+    "foo",
+    "--ignore-workspace-root-check",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with --save-dev 1`] = `
+Array [
+  "pnpm",
+  Array [
+    "add",
+    "foo",
+    "--save-dev",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with all arguments 1`] = `
+Array [
+  "pnpm",
+  Array [
+    "add",
+    "foo",
+    "--save-dev",
+    "--ignore-workspace-root-check",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
 exports[`installer .install when using yarn given a dependency with missing peerDependencies given peerDependencies set to false should not install peerDependencies 1`] = `
 Array [
   Array [
@@ -55,5 +205,96 @@ Array [
       ],
     },
   ],
+]
+`;
+
+exports[`installer .install when using yarn given a dependency with package manager options should install it with --dev 1`] = `
+Array [
+  "yarn",
+  Array [
+    "add",
+    "foo",
+    "--dev",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using yarn given a dependency with package manager options should install it with --ignore-scripts 1`] = `
+Array [
+  "yarn",
+  Array [
+    "add",
+    "foo",
+    "--ignore-scripts",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using yarn given a dependency with package manager options should install it with --silent when quiet is true 1`] = `
+Array [
+  "yarn",
+  Array [
+    "add",
+    "foo",
+    "--silent",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using yarn given a dependency with package manager options should install it with all arguments 1`] = `
+Array [
+  "yarn",
+  Array [
+    "add",
+    "foo",
+    "--dev",
+    "--ignore-scripts",
+    "--silent",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
+]
+`;
+
+exports[`installer .install when using yarn given a dependency without a package.json present should install without options 1`] = `
+Array [
+  "yarn",
+  Array [
+    "add",
+    "foo",
+  ],
+  Object {
+    "stdio": Array [
+      "ignore",
+      "pipe",
+      "inherit",
+    ],
+  },
 ]
 `;

--- a/test/__snapshots__/installer.test.js.snap
+++ b/test/__snapshots__/installer.test.js.snap
@@ -152,13 +152,13 @@ Array [
 ]
 `;
 
-exports[`installer .install when using pnpm given a dependency with package manager options should install it with --save-dev 1`] = `
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with --reporter=silent when quiet is true 1`] = `
 Array [
   "pnpm",
   Array [
     "add",
     "foo",
-    "--save-dev",
+    "--reporter=silent",
   ],
   Object {
     "stdio": Array [
@@ -170,13 +170,13 @@ Array [
 ]
 `;
 
-exports[`installer .install when using pnpm given a dependency with package manager options should install it with --silent when quiet is true 1`] = `
+exports[`installer .install when using pnpm given a dependency with package manager options should install it with --save-dev 1`] = `
 Array [
   "pnpm",
   Array [
     "add",
     "foo",
-    "--reporter=silent",
+    "--save-dev",
   ],
   Object {
     "stdio": Array [

--- a/test/__snapshots__/plugin.test.js.snap
+++ b/test/__snapshots__/plugin.test.js.snap
@@ -15,7 +15,6 @@ Array [
         "type": "npm",
       },
       "prompt": true,
-      "quiet": false,
     },
     WebpackLogger {
       "getChildLogger": [Function],
@@ -34,7 +33,6 @@ Array [
     },
     "packageManager": "npm",
     "prompt": true,
-    "quiet": false,
   },
   WebpackLogger {
     "getChildLogger": [Function],

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -35,6 +35,18 @@ exports[`validation should throw an error on the "packageManager" option with "{
    -> Install as development dependencies"
 `;
 
+exports[`validation should throw an error on the "packageManager" option with "{"type":"npm","options":{"quiet":"foo"}}" value 1`] = `
+"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
+ - options.packageManager.options.quiet should be a boolean.
+   ->  Reduce amount of console logging"
+`;
+
+exports[`validation should throw an error on the "packageManager" option with "{"type":"npm","options":{"test":"foo"}}" value 1`] = `
+"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
+ - options.packageManager.options has an unknown property 'test'. These properties are valid:
+   object { arguments?, dev?, quiet? }"
+`;
+
 exports[`validation should throw an error on the "packageManager" option with "foo" value 1`] = `
 "Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
  - options.packageManager should be one of these:
@@ -59,16 +71,4 @@ exports[`validation should throw an error on the "prompt" option with "bar" valu
 "Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
  - options.prompt should be a boolean.
    -> Show a prompt to confirm installation."
-`;
-
-exports[`validation should throw an error on the "quiet" option with "10" value 1`] = `
-"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
- - options.quiet should be a boolean.
-   ->  Reduce amount of console logging"
-`;
-
-exports[`validation should throw an error on the "quiet" option with "bar" value 1`] = `
-"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
- - options.quiet should be a boolean.
-   ->  Reduce amount of console logging"
 `;

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -18,6 +18,17 @@ exports[`validation should throw an error on the "packageManager" option with "{
    \\"npm\\" | \\"pnpm\\" | \\"yarn\\""
 `;
 
+exports[`validation should throw an error on the "packageManager" option with "{"type":"npm","options":{"arguments":"10"}}" value 1`] = `
+"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
+ - options.packageManager.options.arguments should be an array:
+   [non-empty string, ...] (should not have fewer than 1 item)"
+`;
+
+exports[`validation should throw an error on the "packageManager" option with "{"type":"npm","options":{"arguments":[]}}" value 1`] = `
+"Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
+ - options.packageManager.options.arguments should be an non-empty array."
+`;
+
 exports[`validation should throw an error on the "packageManager" option with "{"type":"npm","options":{"dev":"foo"}}" value 1`] = `
 "Invalid options object. Install Plugin has been initialized using an options object that does not match the API schema.
  - options.packageManager.options.dev should be a boolean.

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -558,14 +558,14 @@ describe('installer', () => {
             jest.clearAllMocks();
           });
 
-          it('should install it with --ignore-workspace-root-check', async () => {
+          it('should install it with --save-dev', async () => {
             await installer.install(
               'foo',
               {
                 packageManager: {
                   type: 'pnpm',
                   options: {
-                    arguments: ['--ignore-workspace-root-check'],
+                    dev: true,
                   },
                 },
               },
@@ -577,14 +577,33 @@ describe('installer', () => {
             expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
 
-          it('should install it with --save-dev', async () => {
+          it('should install it with --reporter=silent when quiet is true', async () => {
             await installer.install(
               'foo',
               {
                 packageManager: {
                   type: 'pnpm',
                   options: {
-                    dev: true,
+                    quiet: true,
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with --ignore-workspace-root-check', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'pnpm',
+                  options: {
+                    arguments: ['--ignore-workspace-root-check'],
                   },
                 },
               },

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -21,10 +21,6 @@ describe('installer', () => {
     it('should default dependencies.peer to true', () => {
       expect(installer.defaultOptions.dependencies.peer).toEqual(true);
     });
-
-    it('should default quiet to false', () => {
-      expect(installer.defaultOptions.quiet).toEqual(false);
-    });
   });
 
   describe('.check', () => {
@@ -379,13 +375,17 @@ describe('installer', () => {
           });
         });
 
-        describe('with quiet set to true', () => {
-          it('should install it with --silent --noprogress', async () => {
+        describe('with package manager arguments', () => {
+          it('should install it with --silent', async () => {
             await installer.install(
               'foo',
               {
-                quiet: true,
-                packageManager: 'yarn',
+                packageManager: {
+                  type: 'yarn',
+                  options: {
+                    arguments: ['--silent'],
+                  },
+                },
               },
               logger
             );
@@ -697,12 +697,17 @@ describe('installer', () => {
           });
         });
 
-        describe('with quiet set to true', () => {
-          it('should install it with --silent --noprogress', async () => {
+        describe('with package manager arguments', () => {
+          it('should install it with --silent --no-progress arguments', async () => {
             await installer.install(
               'foo',
               {
-                quiet: true,
+                packageManager: {
+                  type: 'npm',
+                  options: {
+                    arguments: ['--silent', '--no-progress'],
+                  },
+                },
               },
               logger
             );

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -18,6 +18,18 @@ describe('installer', () => {
       expect(installer.defaultOptions.packageManager.type).toEqual('npm');
     });
 
+    it(`should default packageManager.options.dev to false`, () => {
+      expect(installer.defaultOptions.packageManager.options.dev).toEqual(
+        false
+      );
+    });
+
+    it(`should default packageManager.options.quiet to false`, () => {
+      expect(installer.defaultOptions.packageManager.options.quiet).toEqual(
+        false
+      );
+    });
+
     it('should default dependencies.peer to true', () => {
       expect(installer.defaultOptions.dependencies.peer).toEqual(true);
     });
@@ -327,28 +339,6 @@ describe('installer', () => {
           });
         });
 
-        describe('with dev set to true', () => {
-          it('should install it with --dev', async () => {
-            await installer.install(
-              'foo',
-              {
-                packageManager: {
-                  type: 'yarn',
-                  options: {
-                    dev: true,
-                  },
-                },
-              },
-              logger
-            );
-
-            expect(this.sync).toHaveBeenCalled();
-            expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('yarn');
-            expect(this.sync.mock.calls[0][1]).toEqual(['add', 'foo', '--dev']);
-          });
-        });
-
         describe('without a package.json present', () => {
           beforeEach(() => {
             jest
@@ -370,20 +360,29 @@ describe('installer', () => {
             );
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('yarn');
-            expect(this.sync.mock.calls[0][1]).toEqual(['add', 'foo']);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
         });
 
-        describe('with package manager arguments', () => {
-          it('should install it with --silent', async () => {
+        describe('with package manager options', () => {
+          beforeEach(() => {
+            jest
+              .spyOn(installer, 'packageExists')
+              .mockImplementation(() => true);
+          });
+
+          afterEach(() => {
+            jest.clearAllMocks();
+          });
+
+          it('should install it with --dev', async () => {
             await installer.install(
               'foo',
               {
                 packageManager: {
                   type: 'yarn',
                   options: {
-                    arguments: ['--silent'],
+                    dev: true,
                   },
                 },
               },
@@ -392,12 +391,66 @@ describe('installer', () => {
 
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('yarn');
-            expect(this.sync.mock.calls[0][1]).toEqual([
-              'add',
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with --silent when quiet is true', async () => {
+            await installer.install(
               'foo',
-              '--silent',
-            ]);
+              {
+                packageManager: {
+                  type: 'yarn',
+                  options: {
+                    quiet: true,
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with --ignore-scripts', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'yarn',
+                  options: {
+                    arguments: ['--ignore-scripts'],
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with all arguments', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'yarn',
+                  options: {
+                    dev: true,
+                    quiet: true,
+                    arguments: ['--ignore-scripts'],
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
         });
 
@@ -480,7 +533,7 @@ describe('installer', () => {
 
       describe('given a dependency', () => {
         describe('with no options', () => {
-          it('should install it with --save', async () => {
+          it('should install it without addition arguments', async () => {
             await installer.install(
               'foo',
               {
@@ -490,12 +543,11 @@ describe('installer', () => {
             );
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('pnpm');
-            expect(this.sync.mock.calls[0][1]).toEqual(['add', 'foo']);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
         });
 
-        describe('with dev set to true', () => {
+        describe('with package manager options', () => {
           beforeEach(() => {
             jest
               .spyOn(installer, 'packageExists')
@@ -504,6 +556,25 @@ describe('installer', () => {
 
           afterEach(() => {
             jest.clearAllMocks();
+          });
+
+          it('should install it with --ignore-workspace-root-check', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'pnpm',
+                  options: {
+                    arguments: ['--ignore-workspace-root-check'],
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
 
           it('should install it with --save-dev', async () => {
@@ -522,38 +593,28 @@ describe('installer', () => {
 
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('pnpm');
-            expect(this.sync.mock.calls[0][1]).toEqual([
-              'add',
-              'foo',
-              '--save-dev',
-            ]);
-          });
-        });
-
-        describe('without a package.json present', () => {
-          beforeEach(() => {
-            jest
-              .spyOn(installer, 'packageExists')
-              .mockImplementation(() => false);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
 
-          afterEach(() => {
-            jest.clearAllMocks();
-          });
-
-          it('should install without options', async () => {
+          it('should install it with all arguments', async () => {
             await installer.install(
               'foo',
               {
-                packageManager: 'pnpm',
+                packageManager: {
+                  type: 'pnpm',
+                  options: {
+                    dev: true,
+                    quiet: true,
+                    arguments: ['--ignore-workspace-root-check'],
+                  },
+                },
               },
               logger
             );
+
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('pnpm');
-            expect(this.sync.mock.calls[0][1]).toEqual(['add', 'foo']);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
         });
 
@@ -651,32 +712,6 @@ describe('installer', () => {
           });
         });
 
-        describe('with dev set to true', () => {
-          it('should install it with --save-dev', async () => {
-            await installer.install(
-              'foo',
-              {
-                packageManager: {
-                  type: 'npm',
-                  options: {
-                    dev: true,
-                  },
-                },
-              },
-              logger
-            );
-
-            expect(this.sync).toHaveBeenCalled();
-            expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('npm');
-            expect(this.sync.mock.calls[0][1]).toEqual([
-              'install',
-              'foo',
-              '--save-dev',
-            ]);
-          });
-        });
-
         describe('without a package.json present', () => {
           beforeEach(() => {
             jest
@@ -697,15 +732,25 @@ describe('installer', () => {
           });
         });
 
-        describe('with package manager arguments', () => {
-          it('should install it with --silent --no-progress arguments', async () => {
+        describe('with package manager options', () => {
+          beforeEach(() => {
+            jest
+              .spyOn(installer, 'packageExists')
+              .mockImplementation(() => true);
+          });
+
+          afterEach(() => {
+            jest.clearAllMocks();
+          });
+
+          it('should install it with --save-dev', async () => {
             await installer.install(
               'foo',
               {
                 packageManager: {
                   type: 'npm',
                   options: {
-                    arguments: ['--silent', '--no-progress'],
+                    dev: true,
                   },
                 },
               },
@@ -714,14 +759,66 @@ describe('installer', () => {
 
             expect(this.sync).toHaveBeenCalled();
             expect(this.sync.mock.calls.length).toEqual(1);
-            expect(this.sync.mock.calls[0][0]).toEqual('npm');
-            expect(this.sync.mock.calls[0][1]).toEqual([
-              'install',
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with --silent when quiet is true', async () => {
+            await installer.install(
               'foo',
-              '--save',
-              '--silent',
-              '--no-progress',
-            ]);
+              {
+                packageManager: {
+                  type: 'npm',
+                  options: {
+                    quiet: true,
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with --ignore-scripts', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'npm',
+                  options: {
+                    arguments: ['--ignore-scripts'],
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
+          });
+
+          it('should install it with all arguments', async () => {
+            await installer.install(
+              'foo',
+              {
+                packageManager: {
+                  type: 'npm',
+                  options: {
+                    dev: true,
+                    quiet: true,
+                    arguments: ['--ignore-scripts'],
+                  },
+                },
+              },
+              logger
+            );
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.mock.calls.length).toEqual(1);
+            expect(this.sync.mock.calls[0]).toMatchSnapshot();
           });
         });
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -25,7 +25,6 @@ describe('plugin', () => {
         peer: true,
       },
       packageManager: 'npm',
-      quiet: false,
       prompt: true,
     };
 

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -29,12 +29,21 @@ describe('validation', () => {
             dev: true,
           },
         },
+        {
+          type: 'npm',
+          options: {
+            dev: true,
+            arguments: ['--quiet'],
+          },
+        },
         () => {},
       ],
       failure: [
         'foo',
         { type: 'foo' },
         { type: 'npm', options: { dev: 'foo' } },
+        { type: 'npm', options: { arguments: '10' } },
+        { type: 'npm', options: { arguments: [] } },
       ],
     },
     prompt: {

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -33,7 +33,14 @@ describe('validation', () => {
           type: 'npm',
           options: {
             dev: true,
-            arguments: ['--quiet'],
+            quiet: true,
+          },
+        },
+        {
+          type: 'npm',
+          options: {
+            dev: true,
+            arguments: ['--ignore-scripts'],
           },
         },
         () => {},
@@ -42,15 +49,13 @@ describe('validation', () => {
         'foo',
         { type: 'foo' },
         { type: 'npm', options: { dev: 'foo' } },
+        { type: 'npm', options: { quiet: 'foo' } },
         { type: 'npm', options: { arguments: '10' } },
         { type: 'npm', options: { arguments: [] } },
+        { type: 'npm', options: { test: 'foo' } },
       ],
     },
     prompt: {
-      success: [true, false],
-      failure: ['bar', 10],
-    },
-    quiet: {
       success: [true, false],
       failure: ['bar', 10],
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
**If relevant, did you update the documentation?**
No
**Summary**
Allow passing more arguments to the package manager.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes, `options.quiet` was removed in favor of `packageManager.options.quiet`
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No